### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "vaul": "^1.1.0",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -22,6 +23,11 @@ export function log(message: string, source = "express") {
   console.log(`${formattedTime} [${source}] ${message}`);
 }
 
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 export async function setupVite(app: Express, server: Server) {
   const vite = await createViteServer({
     ...viteConfig,
@@ -41,6 +47,7 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
+  app.use(limiter);
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 


### PR DESCRIPTION
Potential fix for [https://github.com/davisdre/OpenWeatherApp/security/code-scanning/1](https://github.com/davisdre/OpenWeatherApp/security/code-scanning/1)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up rate limiting middleware easily. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the route handler that performs the file system access.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server/vite.ts` file.
3. Set up the rate limiter with the desired configuration.
4. Apply the rate limiter to the route handler that performs the file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
